### PR TITLE
Changed script to check for empty Bitwarden organisation

### DIFF
--- a/bitwarden-secrets/CHANGELOG.md
+++ b/bitwarden-secrets/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0
+
+* 🆕 Additional check to ensure at least 1 secret is available before generating `secrets.yaml`.
+* 📈 Updated Bitwarden CLI to 1.14.0
+* ❗ This add-on will now start after Home Assistant
+* ❗ Removed the deprecated `use_username_as_key` option
+
 ## 1.3.0
 
 * 🆕 Do not replace `secrets.yaml` when nothing has changed
@@ -20,40 +27,3 @@
 * 🆕 Added more debug logging
 * 🐞 Bugifx: Made `repeat.interval` optional in config.
 * ❗ Deprecated `use_username_as_key`, this option will be removed in version 1.4.0.
-
-## 1.1.1
-
-* 🆕 Added support for custom `secrets.yaml` location. This is espcially useful for testing and debugging.
-* 🐞 Bugfix: Fixed upper to lower case conversion on field names
-* 🐞 Bugfix: Prevent initial double Bitwarden check for login and Bitwarden sync
-* Reworked logic inside the startup script, preparing for new functionality.
-
-## 1.1.0
-
-* 🆕 Added ability to use item names as secret keys after [community input](https://reddit.com/r/homeassistant/comments/jqw4gf/addon_release_bitwarden_secrets_for_home_assistant/?ref=share&ref_source=link)
-    * Special characters (`[]{}#*!|>?:&,%@- `) will be replaced with an underscore
-    * Repeated underscores will be replaced with a single occurrence
-    * The item name will be converted to lowercase
-* 🆕 For each username in an item, an entry will be created: `item_name_username`
-* 🆕 For each password in an item, an entry will be created: `item_name_password`
-* 🆕 Also retained the old functionality with a feature flag
-* 🐞 Fix: Added single quotes to YAML values in `secrets.yaml`
-
-## 1.0.3
-
-* 🐞 Added missing sync action when updating passwords
-    * Syncing Bitwarden CLI with your Bitwarden vault was not built-in thus not updating your secrets.
-* 🐞 Slight optimization to Bitwarden CLI Docker image
-* 🆕 Pinned version number of Bitwarden CLI
-
-## 1.0.2
-
-* 🐞 Fixed newlines within secret files
-
-## 1.0.1
-
-* 🆕 Added support for subdirectories with secret files
-
-## 1.0.0
-
-* 🆕 Initial release

--- a/bitwarden-secrets/DOCS.md
+++ b/bitwarden-secrets/DOCS.md
@@ -82,7 +82,6 @@ bitwarden:
 repeat:
   active: false
   interval: 300
-use_username_as_key: false
 ```
 
 ### Option `log_level` (required)
@@ -130,9 +129,3 @@ Interval, in seconds, to refresh your secrets from Bitwarden. This value is only
 ### option `secret_file` (optional)
 
 Optionally define an alternative secret file to parse the secrets into. Providing this value can be useful for testing and debugging this add-on. This file will still be put inside your Home Assistant configuration directory.
-
-### Option `use_username_as_key` (optional) _(deprecated)_
-
-When set to `true` the username of an item will be set as a key in `secrets.yaml`, when omitted or set to `false` the item name will be used as a key. 
-
-> _**NOTE** Thiw is old behaviour introduced with version 1.0.0 and deprecated as of version 1.3.0._

--- a/bitwarden-secrets/build.json
+++ b/bitwarden-secrets/build.json
@@ -7,6 +7,6 @@
         "i386": "hassioaddons/base"
     },
     "args": {
-        "BW_CLI_VERSION": "1.13.3"
+        "BW_CLI_VERSION": "1.14.0"
     }
 }

--- a/bitwarden-secrets/config.json
+++ b/bitwarden-secrets/config.json
@@ -1,10 +1,10 @@
 {
   "name": "Bitwarden secrets for Home Assistant",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "slug": "bw-cli-secrets",
   "description": "Manage Home Assistant secrets easily from Bitwarden.",
   "arch": ["armhf", "armv7", "amd64", "aarch64", "i386"],
-  "startup": "system",
+  "startup": "application",
   "stage": "stable",
   "boot": "auto",
   "url": "https://alxx.nl/home-assistant-addons/tree/master/bitwarden-secrets",
@@ -36,7 +36,6 @@
       "enabled": "bool",
       "interval": "int?"
     },
-    "secrets_file": "str?",
-    "use_username_as_key": "bool?"
+    "secrets_file": "str?"
   }
 }


### PR DESCRIPTION
This change will check whether or not any passwords are found within a Bitwarden organisation. This will probably fix #18, but is also a general improvement.