### PR TITLE
Adding Traefik pilot support

### DIFF
--- a/traefik/DOCS.md
+++ b/traefik/DOCS.md
@@ -146,6 +146,12 @@ Manually set the DNS servers to use when performing the verification step. Usefu
 
 For more information, see the [Traefik documentation](https://docs.traefik.io/https/acme/#resolvers) regarding this subject.
 
+### Option `pilot_token`
+
+Manually set the Traefik pilot token to connect the instance to your pilot account for monitoring.
+
+For more information, go on the [Traefik pilot website](https://https://pilot.traefik.io/).
+
 ### Option `env_vars`
 
 Optional environment variables that can be added. These additional configuration values can be necessary for example for the Let's Encrypt DNS challange provider. See the example configuration above for an concrete example.

--- a/traefik/config.json
+++ b/traefik/config.json
@@ -31,6 +31,7 @@
       "enabled": false,
       "resolvers": []
     },
+    "pilot_token": "",
     "env_vars": []
   },
   "schema": {
@@ -46,6 +47,7 @@
       "delayBeforeCheck": "int?",
       "resolvers": ["str?"]
     },
+    "pilot_token": "str?",
     "env_vars": ["str"]
   }
 }

--- a/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
+++ b/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
@@ -20,6 +20,9 @@ entryPoints:
 api:
   dashboard: true
   insecure: true
+  
+pilot:
+    token: {{ $options.pilot_token }}
 
 {{ if and (has $options "letsencrypt") ($options.letsencrypt.enabled) -}}
 certificatesResolvers:

--- a/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
+++ b/traefik/rootfs/etc/traefik/traefik.yaml.gotmpl
@@ -20,9 +20,11 @@ entryPoints:
 api:
   dashboard: true
   insecure: true
-  
+
+{{- if has $options "pilot_token" }}
 pilot:
-    token: {{ $options.pilot_token }}
+  token: {{ $options.pilot_token }}
+{{- end }}
 
 {{ if and (has $options "letsencrypt") ($options.letsencrypt.enabled) -}}
 certificatesResolvers:


### PR DESCRIPTION
A very simple modification to add the pilot token as an option in the configuration. I hope this is useful.
See https://pilot.traefik.io/ for more information.