### PR TITLE
Add Newline between different Entries

### DIFF
--- a/bitwarden-secrets/run.sh
+++ b/bitwarden-secrets/run.sh
@@ -89,9 +89,11 @@ function generate_secrets {
     touch ${TEMP_SECRETS_FILE}
     
     printf "# Home Assistant secrets file\n" >> ${TEMP_SECRETS_FILE}
-    printf "# DO NOT MODIFY -- Managed by Bitwarden Secrets for Home Assistant add-on\n\n" >> ${TEMP_SECRETS_FILE}
+    printf "# DO NOT MODIFY -- Managed by Bitwarden Secrets for Home Assistant add-on\n" >> ${TEMP_SECRETS_FILE}
 
     for row in $(bw list items --organizationid ${BW_ORG_ID} | jq -c '.[] | select(.type == 1) | (.|@base64)'); do
+        printf "\n" >> ${TEMP_SECRETS_FILE}
+        
         row_contents=$(echo ${row} | jq -r '@base64d')
         name=$(echo $row_contents | jq -r '.name' | tr '?:&,%@-' ' ' | tr '[]{}#*!|> ' '_' | tr -s '_' | tr '[:upper:]' '[:lower:]')
         


### PR DESCRIPTION
For a better overview in the secrest.yaml file I added newlines between different items.
Example:
Before:
```yaml
# Home Assistant secrets file
# DO NOT MODIFY -- Managed by Bitwarden Secrets for Home Assistant add-on

node_red_secret_key: 'dsfnlljdgvbhklj'
node_red_http_user: 'dgs  bhjkdgvb hjkgdvfbhj g'
node_red_http_password: 'hknjlegchkregjgvrknjl'
samba_share_username: 'sdfcgafdshvbj fbh j'
samba_share_password: 'guavjebbjhkv eds afghvbj'
ssh_username: 'khj lgdsvhj dgkvsfd jbk'
ssh_password: 'gbjkdnbhjcdgncdbh'
```

After:
```yaml
# Home Assistant secrets file
# DO NOT MODIFY -- Managed by Bitwarden Secrets for Home Assistant add-on

node_red_secret_key: 'dsfnlljdgvbhklj'
node_red_http_user: 'dgs  bhjkdgvb hjkgdvfbhj g'
node_red_http_password: 'hknjlegchkregjgvrknjl'

samba_share_username: 'sdfcgafdshvbj fbh j'
samba_share_password: 'guavjebbjhkv eds afghvbj'

ssh_username: 'khj lgdsvhj dgkvsfd jbk'
ssh_password: 'gbjkdnbhjcdgncdbh'
```