### PR TITLE
WIP: Core reload when updating secrets

### DIFF
--- a/bitwarden-secrets/config.yaml
+++ b/bitwarden-secrets/config.yaml
@@ -14,11 +14,12 @@ stage: stable
 boot: auto
 url: https://alxx.nl/home-assistant-addons/tree/master/bitwarden-secrets
 hassio_role: default
-hassio_api: true
+homeassistant_api: true
 map:
   - config:rw
 options:
   log_level: info
+  reload_core: false
   bitwarden:
     server: http://a0d7b954-bitwarden:7277/
     username: homeassistant@localhost.lan
@@ -29,6 +30,7 @@ options:
     interval: 300
 schema:
   log_level: list(trace|debug|info|notice|warning|error|fatal)
+  reload_core: bool
   bitwarden:
     server: str
     username: str

--- a/bitwarden-secrets/run.sh
+++ b/bitwarden-secrets/run.sh
@@ -218,16 +218,16 @@ while true; do
             bashio::log.info "Changes from Bitwarden detected, replacing ${SECRETS_FILE}..."
             mv -f ${TEMP_SECRETS_FILE} ${SECRETS_FILE}
             chmod go-wrx ${SECRETS_FILE}
+
+            if [ "${RELOAD_CORE}" == "true" ]; then
+                bashio::log.debug "Checking and reloading core..."
+                reload_core_config
+            fi
         fi
         
         bashio::log.debug "Generating secret files from notes..."
         generate_secret_files
         bashio::log.info "Secret files created."
-        
-        if [ "${RELOAD_CORE}" == "true" ]; then
-            bashio::log.debug "Checking and reloading core..."
-            reload_core_config
-        fi
     else
         bashio::log.error "No secrets found in your organisation!"
         bashio::log.error "--------------------------------------"


### PR DESCRIPTION
This PR will reload HA Core when updating secrets from Bw-cli. This will fix #26.